### PR TITLE
FIX: "--model" option does not exist when creating an interface

### DIFF
--- a/Tests/CommandTest.php
+++ b/Tests/CommandTest.php
@@ -34,13 +34,13 @@ class CommandTest extends TestCase
 
         $this->artisan('make:action Sample -f')->assertSuccessful();
 
-        $this->artisan('make:interface SampleInterface')->assertSuccessful();
+        $this->artisan('make:interfaceclass SampleInterface')->assertSuccessful();
 
-        $this->artisan('make:interface SampleInterface -f')->assertSuccessful();
+        $this->artisan('make:interfaceclass SampleInterface -f')->assertSuccessful();
 
-        $this->artisan('make:interface UserRepositoryInterface --model=User')->assertSuccessful();
+        $this->artisan('make:interfaceclass UserRepositoryInterface --model=User')->assertSuccessful();
 
-        $this->artisan('make:interface UserRepositoryInterface --model=User -f')->assertSuccessful();
+        $this->artisan('make:interfaceclass UserRepositoryInterface --model=User -f')->assertSuccessful();
 
         $this->artisan('make:repository UserRepository --interface=UserRepositoryInterface --model=User')->assertSuccessful();
 

--- a/src/Console/Commands/MakeInterfaceCommand.php
+++ b/src/Console/Commands/MakeInterfaceCommand.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
-#[AsCommand(name: 'make:interface')]
+#[AsCommand(name: 'make:interfaceclass')]
 class MakeInterfaceCommand extends GeneratorCommand
 {
     /**
@@ -15,7 +15,7 @@ class MakeInterfaceCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $name = 'make:interface';
+    protected $name = 'make:interfaceclass';
 
     /**
      * The name of the console command.
@@ -26,7 +26,7 @@ class MakeInterfaceCommand extends GeneratorCommand
      *
      * @deprecated
      */
-    protected static $defaultName = 'make:interface';
+    protected static $defaultName = 'make:interfaceclass';
 
     /**
      * The console command description.


### PR DESCRIPTION
This PR fixes a bug that is present when this package is installed on a Laravel 11 project.
Laravel 11 now ships with make:interface and that clashes with this package's make:interface. 

```bash
php artisan make:repository UserRepository --model=User -c
```