### PR TITLE
Fix: "The "--model" option does not exist." when generating repositories.

### DIFF
--- a/src/Console/Commands/MakeRepositoryCommand.php
+++ b/src/Console/Commands/MakeRepositoryCommand.php
@@ -55,7 +55,7 @@ class MakeRepositoryCommand extends GeneratorCommand
 
         if ($this->option('contract')) {
             $interface = $model . "RepositoryInterface";
-            $this->call('make:interface', ['name' => $interface, '--model' => $model]);
+            $this->call('make:interfaceclass', ['name' => $interface, '--model' => $model]);
         } else {
             $interface = $this->option('interface');
         }


### PR DESCRIPTION
This is a complete fix to this [PR](https://github.com/ikechukwukalu/makeservice/pull/3#issue-2485828715)