### PR TITLE
Feature: Trigger model events on update

### DIFF
--- a/src/Console/Commands/stubs/repository-user.stub
+++ b/src/Console/Commands/stubs/repository-user.stub
@@ -17,7 +17,7 @@ class {{ class }} implements {{ interface }}
      */
     public function getAll(): EloquentCollection
     {
-        return {{ model }}::all();
+        return {{ model }}::get();
     }
 
     /**

--- a/src/Console/Commands/stubs/repository-user.stub
+++ b/src/Console/Commands/stubs/repository-user.stub
@@ -74,7 +74,7 @@ class {{ class }} implements {{ interface }}
      */
     public function update(int|string $id, array $arrayDetails): int
     {
-        return {{ model }}::where('id', $id)->update($arrayDetails);
+        return {{ model }}::find($id)->update($arrayDetails);
     }
 
     /**

--- a/src/Console/Commands/stubs/repository.stub
+++ b/src/Console/Commands/stubs/repository.stub
@@ -17,7 +17,7 @@ class {{ class }} implements {{ interface }}
      */
     public function getAll(): EloquentCollection
     {
-        return {{ model }}::all();
+        return {{ model }}::get();
     }
 
     /**

--- a/src/Console/Commands/stubs/repository.stub
+++ b/src/Console/Commands/stubs/repository.stub
@@ -74,7 +74,7 @@ class {{ class }} implements {{ interface }}
      */
     public function update(int|string $id, array $arrayDetails): int
     {
-        return {{ model }}::where('id', $id)->update($arrayDetails);
+        return {{ model }}::find($id)->update($arrayDetails);
     }
 
     /**


### PR DESCRIPTION
This allows for mass update via eloquent to ensure the model events are fired when the model is updated. 

Taking a code snippet from [Stack Overflow](https://stackoverflow.com/questions/41295032/laravel-eloquent-model-update-event-is-not-fired) 
This will NOT fire the update event:
`User::where('id', $id)->update(['username' => $newUsername]);
`
This will fire the update event:
`User::find($id)->update(['username' => $newUsername]);
`

Also when fetching all records in a model, using get() would allow us to load model relationships.
For instance
`User::with('comments')->all()` will throw an error
`User::with('comments')->get()` won't throw an error